### PR TITLE
test for comparing surfaces when there is no common value

### DIFF
--- a/IsogeomGenerator/isg.py
+++ b/IsogeomGenerator/isg.py
@@ -620,7 +620,8 @@ class IsGm(IsoGeomGen):
                         list(set(self.isovol_meshsets[v1]['bounds']) &
                              set(self.isovol_meshsets[v2]['bounds']))
                     if not(bool(shared)):
-                        print('no matching value!', v1, v2)
+                        warnings.warn("No matching value for volumes " +
+                                    "{} and {}".format(v1, v2))
                         val = 0.0
                     else:
                         val = shared[0] * norm

--- a/tests/test_isg.py
+++ b/tests/test_isg.py
@@ -681,18 +681,16 @@ def test_compare_surfs_no_val():
     """no matching value - should throw warning"""
     # get setup
     ig = __setup_geom()
-    ivs = sorted(ig.isovol_meshsets.keys())  # isovol info: (vol id, EH)
-    iv1 = ivs[0]
-    iv2 = ivs[1]
-    fs1 = list(iv1)[1]
-    fs2 = list(iv2)[1]
+    iv = sorted(ig.isovol_meshsets.keys())  # isovol info: (vol id, EH)
+    fs1 = list(iv[0])[1]
+    fs2 = list(iv[1])[1]
     # change level info on one so there is no common value
-    ig.isovol_meshsets[iv2]['bounds'] = (6., 10.)
+    ig.isovol_meshsets[iv[1]]['bounds'] = (6., 10.)
     # compare surfs
     norm = 1.5
     merge_tol = 1.e-5
     with pytest.warns(None) as warn_info:
-        ig._IsGm__compare_surfs(iv1, iv2, norm, merge_tol)
+        ig._IsGm__compare_surfs(iv[0], iv[1], norm, merge_tol)
     # checks
     r = np.full(2, False)
     # should raise a warning

--- a/tests/test_isg.py
+++ b/tests/test_isg.py
@@ -679,4 +679,31 @@ def test_compare_surfs_full_surf():
 
 def test_compare_surfs_no_val():
     """no matching value - should throw warning"""
-    pass
+    # get setup
+    ig = __setup_geom()
+    ivs = sorted(ig.isovol_meshsets.keys())  # isovol info: (vol id, EH)
+    iv1 = ivs[0]
+    iv2 = ivs[1]
+    fs1 = list(iv1)[1]
+    fs2 = list(iv2)[1]
+    # change level info on one so there is no common value
+    ig.isovol_meshsets[iv2]['bounds'] = (6., 10.)
+    # compare surfs
+    norm = 1.5
+    merge_tol = 1.e-5
+    with pytest.warns(None) as warn_info:
+        ig._IsGm__compare_surfs(iv1, iv2, norm, merge_tol)
+    # checks
+    r = np.full(2, False)
+    # should raise a warning
+    if len(warn_info) == 1:
+        r[0] = True
+    # common surface should be assigned a value of 0.0
+    surfs_1 = ig.isovol_meshsets[iv1]['surfs_EH']
+    surfs_2 = ig.isovol_meshsets[iv2]['surfs_EH']
+    common_surf = set(surfs_1) & set(surfs_2)
+    val_out = ig.mb.tag_get_data(ig.val_tag, common_surf)[0][0]
+    val_exp = 0.0
+    if val_out == val_exp:
+        r[1] = True
+    assert(all(r))

--- a/tests/test_isg.py
+++ b/tests/test_isg.py
@@ -169,6 +169,7 @@ def test_read_database_nolevels_error():
 
 
 def test_separate_isovols():
+    """test that disjoint volumes are properly separated"""
     # load mesh that needs separation
     ig = isg.IsGm()
     fs = ig.mb.create_meshset()
@@ -199,6 +200,7 @@ def test_separate_isovols():
 
 
 def test_separate_isovols_single():
+    """test a single vol is unchanged when it goes through separation"""
     # load mesh that does not need separation
     ig = isg.IsGm()
     print(ig)
@@ -225,6 +227,7 @@ def test_separate_isovols_single():
 
 
 def __setup_geom():
+    """function for other tests to create a useable isogeom object"""
     # load two coincident volumes that need merging
     ig = isg.IsGm()
     fs1 = ig.mb.create_meshset()
@@ -245,6 +248,7 @@ def __setup_geom():
 
 
 def test_imprint_merge():
+    """test mesh imprint and merge capability"""
     # get setup
     ig = __setup_geom()
     ivs = sorted(ig.isovol_meshsets.keys())  # isovol info: (vol id, EH)
@@ -297,6 +301,7 @@ def test_imprint_merge():
 
 
 def test_make_family():
+    """test tags are added properly"""
     # get setup
     ig = __setup_geom()
     ivs = sorted(ig.isovol_meshsets.keys())  # isovol info: (vol id, EH)
@@ -417,6 +422,7 @@ def test_make_family():
 
 
 def test_tag_for_viz():
+    """test visualization tags are added to triangles"""
     # load volume
     ig = isg.IsGm()
     fs = ig.mb.create_meshset()
@@ -445,6 +451,7 @@ def test_tag_for_viz():
                           ('str_tag', 'val', 'str_tag', ['val'], np.string_),
                           (1.0, 'convert', '1.0', ['convert'], np.string_)])
 def test_set_tags(tagname, tagval, expname, expval, exptype):
+    """test tags are set on root set for various lengths and data types."""
     ig = isg.IsGm()
     tags = {tagname: tagval}
     # set tags
@@ -555,6 +562,7 @@ def test_list_coords_invert():
 
 
 def test_get_matches():
+    """test that coordinates are properly identified as matching"""
     # create instance
     ig = isg.IsGm()
     # set up verts to test:
@@ -588,6 +596,7 @@ def test_get_matches():
 
 
 def test_get_matches_approx():
+    """test coords are identified as matching if approximate matches"""
     # create instance
     ig = isg.IsGm()
     # set up verts to test:
@@ -621,6 +630,7 @@ def test_get_matches_approx():
 
 
 def test_compare_surfs():
+    """test that new surf is correctly generated when comparing two"""
     # get setup
     ig = __setup_geom()
     ivs = sorted(ig.isovol_meshsets.keys())  # isovol info: (vol id, EH)


### PR DESCRIPTION
This tests that a warning is thrown when two adjacent volumes don't share a common level value in the the two values that are used to generate a single isovolume. Expected behavior is that there is a common value, but if there is not, there is a warning and a value of 0 is used. (function being tests `__compare_surfs()`)