### PR TITLE
Fix levels + database naming

### DIFF
--- a/IsogeomGenerator/isg.py
+++ b/IsogeomGenerator/isg.py
@@ -96,7 +96,7 @@ class IsGm(IsoGeomGen):
 
         # check there are correct number of files:
         file_list = sorted(os.listdir(self.db + "/vols/"))
-        if len(self.levels) + 1 != len(file_list):
+        if len(self.levels) != len(file_list):
             raise RuntimeError("Number of levels does not match number of " +
                                "isovolume files in the database.")
 

--- a/tests/test_isg.py
+++ b/tests/test_isg.py
@@ -13,7 +13,7 @@ from IsogeomGenerator import isg, ivdb
 test_dir = getcwd() + "/tests/test_files/"
 test_mesh = test_dir + "test_mesh.vtk"
 data = 'dname'
-levels = [15, 5, 25, 35]
+levels = [15, 5, 25, 35, 45]
 exp_db = test_dir + "/exp-test/"
 exp_vols_dir = exp_db + "/vols"
 common_files = [f for f in listdir(exp_vols_dir)
@@ -49,7 +49,7 @@ def test_init_none():
 
 def test_init_input():
     r = np.full(3, False)
-    ig = isg.IsGm(levels=levels, data=data, db=exp_db)
+    ig = isg.IsGm(levels=exp_levels, data=data, db=exp_db)
     if ig.levels == exp_levels:
         r[0] = True
     if ig.data == data:

--- a/tests/test_ivdb.py
+++ b/tests/test_ivdb.py
@@ -152,7 +152,7 @@ def test_make_db_dir_exists():
     if isdir(db):
         shutil.rmtree(db)
     mkdir(db)
-    db_exp = test_dir + "/test-direxists-1/"
+    db_exp = test_dir + "/test-direxists_1/"
     iv = ivdb.IvDb(levels=levels, data=data, db=db)
     with pytest.warns(None) as warn_info:
         iv._IvDb__make_db_dir()


### PR DESCRIPTION
There are two fixes in this PR that I discovered were necessary:

1. There was an issue with the handling of no data to export when the max level was being used. The previous method was that the upper bound would be removed from the level list and moved on to the next level in the list to try again. When the upper bound was set to the `arbmax` value though there would be no next level to try, nor could it remove that `arbmax` level. This is solved by adding the `arbmax` value as a level in the level list. (see `isg.py`). Tests have been updated accordingly.
2. The automatic database naming scheme has been updated to use an underscore instead of a dash to prevent the situation where the directory might accidentally be named starting with that symbol.