### PR TITLE
Mesh refine

### DIFF
--- a/IsogeomGenerator/refine_isogeom.py
+++ b/IsogeomGenerator/refine_isogeom.py
@@ -127,7 +127,8 @@ def apply_filters(fname, df, sf, surf_type):
             be applied. A higher value indicates more smoothing.
         surf_type: str, 'interior' or 'exterior', used to indicate if
             the surface being refined is an interior or exterior surface.
-            Only interior surfaces will have smoothing applied if smoothing is requested.
+            Only interior surfaces will have smoothing applied if
+            smoothing is requested.
 
     Return:
     -------
@@ -165,7 +166,7 @@ def apply_filters(fname, df, sf, surf_type):
         # preserve topology (splitting or hole elimination not allowed)
         decifilter.SetPreserveTopology(True)
         decifilter.SetSplitting(False)  # no mesh splitting allowed
-        # no boundary vertex (eddge/curve) deletion allowed
+        # no boundary vertex (edge/curve) deletion allowed
         decifilter.SetBoundaryVertexDeletion(False)
         decifilter.Update()
         pdport = decifilter.GetOutputPort()

--- a/IsogeomGenerator/refine_isogeom.py
+++ b/IsogeomGenerator/refine_isogeom.py
@@ -82,29 +82,32 @@ def apply_filters(fname, decimate, df, smooth, sf):
     pdport = gf.GetOutputPort()
 
     if smooth:
-        pass
+        smoothfilter = vtk.vtkSmoothPolyDataFilter()
+        smoothfilter.SetInputConnection(pdport)
+        smoothfilter.SetNumberOfIterations(200)
+        smoothfilter.SetRelaxationFactor(sf)
+        smoothfilter.BoundarySmoothingOff()
+        smoothfilter.FeatureEdgeSmoothingOff()
+        smoothfilter.Update()
+        pdport = smoothfilter.GetOutputPort()
 
     if decimate:
         # setup decimate operator
-        deci = vtk.vtkDecimatePro()
-        deci.SetInputConnection(pdport)
+        decifilter = vtk.vtkDecimatePro()
+        decifilter.SetInputConnection(pdport)
         # set decimate options
-        deci.SetTargetReduction(df)  # target reduction
+        decifilter.SetTargetReduction(df)  # target reduction
         # preserve topology (splitting or hole elimination not allowed)
-        deci.SetPreserveTopology(True)
-        deci.SetSplitting(False)  # no mesh splitting allowed
+        decifilter.SetPreserveTopology(True)
+        decifilter.SetSplitting(False)  # no mesh splitting allowed
         # no boundary vertex (eddge/curve) deletion allowed
-        deci.SetBoundaryVertexDeletion(False)
-        deci.Update()
-        deciport = deci.GetOutputPort()
+        decifilter.SetBoundaryVertexDeletion(False)
+        decifilter.Update()
+        pdport = decifilter.GetOutputPort()
 
     # convert polydata back to USG
     appendfilter = vtk.vtkAppendFilter()
-    if smooth:
-        # append smooth filter too
-        pass
-    if decimate:
-        appendfilter.SetInputConnection(deciport)
+    appendfilter.SetInputConnection(pdport)
     appendfilter.Update()
     usg_new = vtk.vtkUnstructuredGrid()
     usg_new.ShallowCopy(appendfilter.GetOutput())

--- a/IsogeomGenerator/refine_isogeom.py
+++ b/IsogeomGenerator/refine_isogeom.py
@@ -1,0 +1,85 @@
+"""For a given isosurface geometry file, apply mesh refinement techniques.
+
+Mesh Refinements techniques:
+----------------------------
+
+    * Decimate: use fewer triangles in the mesh surfaces
+    * smooth: remove roughness from the surfaces
+"""
+
+import argparse
+from pymoab import core
+
+formatter = argparse.RawDescriptionHelpFormatter
+
+
+def decimate_triangles():
+    """Reduce the number of triangles in the surfaces by user specified
+    amount
+    """
+    pass
+
+
+def smooth_surfaces():
+    """Smooth surfaces by a user-specified factor"""
+    pass
+
+
+def refine_all():
+    """smooth and decimate surfaces. Smoothing will be applied first"""
+    pass
+
+
+def parse_arguments():
+    description = "temp description"
+    usage = "temp usage"
+    examples = "temp examples"
+    parser = argparse.ArgumentParser(description=description,
+                                     usage=usage,
+                                     epilog=examples,
+                                     formatter_class=formatter)
+
+    parser.add_argument('-d', '--decimate',
+                        action='store_true',
+                        required=False,
+                        dest='decimate',
+                        help='If set, decimate surface triangles by the ' +
+                        'decimation factor df.')
+    parser.add_argument('-df', '--decimatefactor',
+                        action='store',
+                        required=False,
+                        default=[0.5],
+                        metavar='DECIMATION_FACTOR',
+                        dest='deci_factor',
+                        help='Decimation factor for triangles (0 < df < 1). ' +
+                        'Higher value means higher reduction in triangles. ' +
+                        'Default value is 0.5.',
+                        type=float
+                        )
+    parser.add_argument('-s', '--smooth',
+                        action='store_true',
+                        required=False,
+                        dest='smooth',
+                        help='If set, smooth surfaces by the ' +
+                        'smoothing factor')
+    parser.add_argument('-sf', '--smoothfactor',
+                        action='store',
+                        required=False,
+                        default=[0.5],
+                        metavar='SMOOTH_FACTOR',
+                        dest='smooth_factor',
+                        help='Smoothing relaxation factor for surfaces (0 < sf < 1). ' +
+                        'Higher value means more smoothing. ' +
+                        'Default value is 0.5.',
+                        type=float
+                        )
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_arguments()
+
+
+if __name__ == "__main__":
+    main()

--- a/IsogeomGenerator/refine_isogeom.py
+++ b/IsogeomGenerator/refine_isogeom.py
@@ -84,12 +84,11 @@ def apply_filters(fname, decimate, df, smooth, sf, surf_type):
     # only apply smoothing filter to interior surfaces to avoid smoothing
     # the corners of the geometry
     if smooth and surf_type == 'interior':
-        smoothfilter = vtk.vtkSmoothPolyDataFilter()
+        smoothfilter = vtk.vtkWindowedSincPolyDataFilter()
         smoothfilter.SetInputConnection(pdport)
-        smoothfilter.SetNumberOfIterations(200)
-        smoothfilter.SetRelaxationFactor(sf)
-        smoothfilter.BoundarySmoothingOff()
-        smoothfilter.FeatureEdgeSmoothingOff()
+        smoothfilter.SetNumberOfIterations(20)
+        smoothfilter.BoundarySmoothingOff  # don't apply to boundaries
+        smoothfilter.NonManifoldSmoothingOff()  # don't collapse topology/vols
         smoothfilter.Update()
         pdport = smoothfilter.GetOutputPort()
 

--- a/IsogeomGenerator/refine_isogeom.py
+++ b/IsogeomGenerator/refine_isogeom.py
@@ -127,7 +127,7 @@ def apply_filters(fname, df, sf, surf_type):
             be applied. A higher value indicates more smoothing.
         surf_type: str, 'interior' or 'exterior', used to indicate if
             the surface being refined is an interior or exterior surface.
-            Only interior surfaces will have smoothing applied if set.
+            Only interior surfaces will have smoothing applied if smoothing is requested.
 
     Return:
     -------
@@ -315,7 +315,7 @@ def refine_surfaces(filename, df, sf, output, keep):
             os.remove(fname)
             os.remove(outfile)
 
-    # wrtite full geometry - only the necessary entities
+    # write full geometry - only the necessary entities
     print("Writing refined geometry")
     all_vols = mb.get_entities_by_type_and_tag(
         rs, types.MBENTITYSET, dim_tag, [3])

--- a/IsogeomGenerator/refine_isogeom.py
+++ b/IsogeomGenerator/refine_isogeom.py
@@ -97,6 +97,13 @@ Examples:
                         dest='output',
                         help='Name to be used for the refined output file. ' +
                         'Default is refined_geom.h5m')
+    parser.add_argument('-k', '--keep',
+                        action='store_true',
+                        required=False,
+                        dest='keep',
+                        help='If set, temporary surfaces files that are ' +
+                        'generated will not be deleted. (Use for debugging).'
+                        )
     args = parser.parse_args()
     return args
 
@@ -153,7 +160,6 @@ def apply_filters(fname, df, sf, surf_type):
     writer1.SetInputData(usg_new)
     writer1.Update()
     writer1.Write()
-    print('wrote {}'.format(outfile))
 
     return outfile
 
@@ -181,7 +187,7 @@ def get_viz_info(mb, surf):
     return data_tag, data_name
 
 
-def refine_surfaces(filename, df, sf, output):
+def refine_surfaces(filename, df, sf, output, keep):
 
     # load as a moab instance
     mb = core.Core()
@@ -244,8 +250,9 @@ def refine_surfaces(filename, df, sf, output):
             mb.tag_set_data(data_tag, tris_new, vals)
 
         # delete temporary files
-        os.remove(fname)
-        os.remove(outfile)
+        if not keep:
+            os.remove(fname)
+            os.remove(outfile)
 
     # wrtite full geometry - only the necessary entities
     print("Writing refined geometry")
@@ -271,8 +278,8 @@ def main():
         args.smooth_factor = 0.5
         args.deci_factor = 0.5
 
-    refine_surfaces(args.geomfile[0], args.deci_factor,
-                    args.smooth_factor, args.output[0])
+    refine_surfaces(args.geomfile[0], args.deci_factor, args.smooth_factor,
+                    args.output[0], args.keep)
 
 
 if __name__ == "__main__":

--- a/IsogeomGenerator/refine_isogeom.py
+++ b/IsogeomGenerator/refine_isogeom.py
@@ -13,14 +13,14 @@ from pymoab import core
 formatter = argparse.RawDescriptionHelpFormatter
 
 
-def decimate_triangles():
+def decimate_triangles(factor):
     """Reduce the number of triangles in the surfaces by user specified
     amount
     """
     pass
 
 
-def smooth_surfaces():
+def smooth_surfaces(factor):
     """Smooth surfaces by a user-specified factor"""
     pass
 
@@ -38,7 +38,13 @@ def parse_arguments():
                                      usage=usage,
                                      epilog=examples,
                                      formatter_class=formatter)
-
+    parser.add_argument('geomfile',
+                        action='store',
+                        nargs=1,
+                        type=str,
+                        help='Relative path an isosurface geometry file to ' +
+                        'be refined.'
+                        )
     parser.add_argument('-d', '--decimate',
                         action='store_true',
                         required=False,
@@ -79,6 +85,11 @@ def parse_arguments():
 
 def main():
     args = parse_arguments()
+
+    if args.smooth:
+        smooth_surfaces(args.smooth_factor[0])
+    if args.decimate:
+        decimate_triangles(args.decimate_factor[0])
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,10 @@ setup(
     description="A package for generating meshed isosurface geometries",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/kkiesling/IsogeomGenerator",
+    url="https://github.com/CNERG/IsogeomGenerator",
     packages=setuptools.find_packages(),
     entry_points={
         'console_scripts':
-        ['generate_isogeom=IsogeomGenerator.generate_isogeom:main']}
+        ['generate_isogeom=IsogeomGenerator.generate_isogeom:main',
+         'refine_isogeom=IsogeomGenerator.refine_isogeom:main']}
 )


### PR DESCRIPTION
(merge after #47 - ignore `isg.py` file as a result, that is in the other PR)

This is the user tool for applying mesh refinement. A completed isosurface geometry is supplied and either smoothing or decimating (or both) can be applied. Temporary files must be written out but then they are deleted (or optionally saved).

Per [this tweet](https://twitter.com/krose621/status/1425179183433633799), I am opening this for review before I have tests written :grimacing:, but also because I haven't completely thought through how I should be testing this.